### PR TITLE
Add interactive setup script for API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ Create a virtual environment and install the required Python packages:
 pip install -r requirements.txt
 ```
 
+## Configuration
+
+Run the setup script to save your API keys in `config.py`:
+
+```bash
+python setup.py
+```
+
 ## Status
 
 The project is still a work in progress and the tools are provided as-is.

--- a/config.py
+++ b/config.py
@@ -4,3 +4,7 @@
 PRINTIFY_API_KEY = "printify api key"
 BASE_URL = "https://api.printify.com/v1"
 OPENAI_API_KEY = "openai api key"
+
+# Optional Google Drive uploader configuration
+GOOGLE_SERVICE_ACCOUNT = "path/to/service_account.json"
+GOOGLE_DRIVE_FOLDER_ID = "drive-folder-id"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Interactive setup for configuring API keys."""
+import json
+from pathlib import Path
+
+CONFIG_FILE = Path('config.py')
+
+def prompt(key, default=""):
+    val = input(f"Enter {key} [{default}]: ").strip()
+    return val or default
+
+def main():
+    print("=== Printify Pilot setup ===")
+    print("This will store your API keys in config.py")
+
+    printify = prompt("Printify API key")
+    openai = prompt("OpenAI API key")
+    g_service = prompt("Path to Google service account JSON", "path/to/service_account.json")
+    g_folder = prompt("Google Drive folder ID", "drive-folder-id")
+
+    lines = [
+        "# config.py",
+        f"PRINTIFY_API_KEY = \"{printify}\"",
+        "BASE_URL = \"https://api.printify.com/v1\"",
+        f"OPENAI_API_KEY = \"{openai}\"",
+        "",
+        "# Optional Google Drive uploader configuration",
+        f"GOOGLE_SERVICE_ACCOUNT = \"{g_service}\"",
+        f"GOOGLE_DRIVE_FOLDER_ID = \"{g_folder}\"",
+        ""
+    ]
+    CONFIG_FILE.write_text("\n".join(lines), encoding="utf-8")
+    print("Configuration written to", CONFIG_FILE)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a `setup.py` script that prompts for Printify, OpenAI and Google Drive keys
- document running the setup script in the README
- expand `config.py` with optional Google Drive settings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c33c9213c832496b8bc023cffa958