### PR TITLE
Add startup script for frontend/backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,25 @@ product data from the Flask backend.
 
 ### Setup
 
+Run the convenience script to install dependencies and launch both the Flask
+backend and the React development server:
+
+```bash
+./start.sh
+```
+
+This starts the backend on `http://localhost:5000` and serves the frontend at
+`http://localhost:8080`.
+
+If you prefer to build the frontend manually:
+
 ```bash
 cd webpack-app
 npm install
 npm run build
 ```
 
-This creates `webpack-app/dist` containing the compiled bundle. Run the Flask
+This creates `webpack-app/dist` containing the compiled bundle. Start the Flask
 backend (`python app.py`) and open `dist/index.html` or use `npm start` for
 live development.
 

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Install Python dependencies
+if [ -f "$DIR/requirements.txt" ]; then
+    echo "Installing Python dependencies..."
+    pip install -r "$DIR/requirements.txt"
+fi
+
+# Install Node dependencies
+if [ -d "$DIR/webpack-app" ]; then
+    echo "Installing Node dependencies..."
+    (cd "$DIR/webpack-app" && npm install)
+fi
+
+# Start Flask backend
+echo "Starting Flask backend..."
+python "$DIR/app.py" &
+FLASK_PID=$!
+
+trap 'kill $FLASK_PID' EXIT
+
+# Start React frontend
+cd "$DIR/webpack-app"
+echo "Starting React dev server..."
+npm start


### PR DESCRIPTION
## Summary
- add `start.sh` to launch Flask backend and React dev server
- update README with instructions for running the new script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c39532b408324a536f50e6b848228