### PR TITLE
Fix failing tests by disabling Printify API

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,7 +1,9 @@
 
 
 # config.py
-PRINTIFY_API_KEY = "printify api key"
+# Use an empty API key by default so tests run without
+# attempting real network calls to Printify.
+PRINTIFY_API_KEY = ""
 BASE_URL = "https://api.printify.com/v1"
 OPENAI_API_KEY = "openai api key"
 


### PR DESCRIPTION
## Summary
- disable Printify API access by default so tests don't attempt real network calls
- run the test suite

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c91ccc11c8324b2c5333b9ce36a86