### PR TITLE
Apply improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ pip install -r requirements.txt
 
 ## Configuration
 
-Run the setup script to save your API keys in `config.py`:
+Configuration values are read from environment variables by default. You can
+optionally run the setup script to generate a `config.py` file:
 
 ```bash
 python setup.py

--- a/config.py
+++ b/config.py
@@ -1,12 +1,38 @@
 
 
-# config.py
-# Use an empty API key by default so tests run without
-# attempting real network calls to Printify.
-PRINTIFY_API_KEY = ""
-BASE_URL = "https://api.printify.com/v1"
-OPENAI_API_KEY = "openai api key"
+"""Central configuration loaded from environment variables."""
+
+from __future__ import annotations
+
+import os
+
+PRINTIFY_API_KEY = os.getenv("PRINTIFY_API_KEY", "")
+BASE_URL = os.getenv("BASE_URL", "https://api.printify.com/v1")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "openai api key")
 
 # Optional Google Drive uploader configuration
-GOOGLE_SERVICE_ACCOUNT = "path/to/service_account.json"
-GOOGLE_DRIVE_FOLDER_ID = "drive-folder-id"
+GOOGLE_SERVICE_ACCOUNT = os.getenv("GOOGLE_SERVICE_ACCOUNT", "path/to/service_account.json")
+GOOGLE_DRIVE_FOLDER_ID = os.getenv("GOOGLE_DRIVE_FOLDER_ID", "drive-folder-id")
+
+
+def require(keys: list[str] | None = None) -> None:
+    """Validate that required keys are present.
+
+    Parameters
+    ----------
+    keys:
+        List of configuration variable names to check. Defaults to
+        ``["PRINTIFY_API_KEY", "OPENAI_API_KEY"]``.
+
+    Raises
+    ------
+    ValueError
+        If any of the required keys are empty.
+    """
+
+    to_check = keys or ["PRINTIFY_API_KEY", "OPENAI_API_KEY"]
+    missing = [k for k in to_check if not globals().get(k)]
+    if missing:
+        joined = ", ".join(missing)
+        raise ValueError(f"Missing required config values: {joined}")
+

--- a/creator_portal/agents/social_media.py
+++ b/creator_portal/agents/social_media.py
@@ -1,7 +1,7 @@
 """Social Media Publishing Agent."""
 
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 
 LOG_PATH = Path(__file__).resolve().parents[1] / 'logs' / 'social_posts.log'
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
@@ -9,7 +9,8 @@ LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 
 def post_to_social(platform: str, content: str) -> dict:
     """Record a social media post to a log file."""
-    entry = f"{datetime.utcnow().isoformat()}Z|{platform}|{content}\n"
+    timestamp = datetime.now(timezone.utc).isoformat()
+    entry = f"{timestamp}|{platform}|{content}\n"
     with LOG_PATH.open('a') as fh:
         fh.write(entry)
     return {'platform': platform, 'content': content, 'logged': True}

--- a/creator_portal/configs/config.py
+++ b/creator_portal/configs/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import os
 from pathlib import Path
 import sys
 
@@ -5,10 +8,15 @@ import sys
 ROOT_CONFIG = Path(__file__).resolve().parents[2] / 'config.py'
 if ROOT_CONFIG.exists():
     sys.path.append(str(ROOT_CONFIG.parent))
-    from config import PRINTIFY_API_KEY, BASE_URL, OPENAI_API_KEY
-    CELERY_BROKER_URL = getattr(sys.modules['config'], 'CELERY_BROKER_URL', 'redis://localhost:6379/0')
+    from config import PRINTIFY_API_KEY, BASE_URL, OPENAI_API_KEY, require
+    CELERY_BROKER_URL = getattr(sys.modules['config'], 'CELERY_BROKER_URL', os.getenv('CELERY_BROKER_URL', 'redis://localhost:6379/0'))
 else:
-    PRINTIFY_API_KEY = ''
-    BASE_URL = 'https://api.printify.com/v1'
-    OPENAI_API_KEY = ''
-    CELERY_BROKER_URL = 'redis://localhost:6379/0'
+    PRINTIFY_API_KEY = os.getenv('PRINTIFY_API_KEY', '')
+    BASE_URL = os.getenv('BASE_URL', 'https://api.printify.com/v1')
+    OPENAI_API_KEY = os.getenv('OPENAI_API_KEY', '')
+    CELERY_BROKER_URL = os.getenv('CELERY_BROKER_URL', 'redis://localhost:6379/0')
+    def require(keys: list[str] | None = None) -> None:
+        missing = [k for k in (keys or ["PRINTIFY_API_KEY", "OPENAI_API_KEY"]) if not globals().get(k)]
+        if missing:
+            joined = ", ".join(missing)
+            raise ValueError(f"Missing required config values: {joined}")


### PR DESCRIPTION
## Summary
- read config from environment variables and add validation helper
- use timezone-aware logging for social media posts
- document env vars in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c955f3110832487e33b9ea309bee3