### PR TITLE
Improve config management and tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+PRINTIFY_API_KEY=your-printify-api-key
+OPENAI_API_KEY=your-openai-api-key
+BASE_URL=https://api.printify.com/v1
+GOOGLE_SERVICE_ACCOUNT=path/to/service_account.json
+GOOGLE_DRIVE_FOLDER_ID=drive-folder-id
+CELERY_BROKER_URL=redis://localhost:6379/0

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ pip install -r requirements.txt
 
 ## Configuration
 
-Configuration values are read from environment variables by default. You can
-optionally run the setup script to generate a `config.py` file:
+Configuration values are read from environment variables. Copy ``.env.example``
+to ``.env`` and fill in your credentials or export them in your shell. You can
+optionally run the setup script to generate a ``config.py`` file:
 
 ```bash
 python setup.py

--- a/config.py
+++ b/config.py
@@ -1,18 +1,29 @@
 
 
-"""Central configuration loaded from environment variables."""
+"""Central configuration loaded from environment variables or an ``.env`` file."""
 
 from __future__ import annotations
 
 import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+# Load variables from a .env file if present
+load_dotenv(Path(__file__).resolve().with_name(".env"))
 
 PRINTIFY_API_KEY = os.getenv("PRINTIFY_API_KEY", "")
 BASE_URL = os.getenv("BASE_URL", "https://api.printify.com/v1")
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "openai api key")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
 
 # Optional Google Drive uploader configuration
-GOOGLE_SERVICE_ACCOUNT = os.getenv("GOOGLE_SERVICE_ACCOUNT", "path/to/service_account.json")
-GOOGLE_DRIVE_FOLDER_ID = os.getenv("GOOGLE_DRIVE_FOLDER_ID", "drive-folder-id")
+GOOGLE_SERVICE_ACCOUNT = os.getenv("GOOGLE_SERVICE_ACCOUNT", "")
+GOOGLE_DRIVE_FOLDER_ID = os.getenv("GOOGLE_DRIVE_FOLDER_ID", "")
+
+
+class ConfigError(ValueError):
+    """Raised when required configuration values are missing."""
+    pass
 
 
 def require(keys: list[str] | None = None) -> None:
@@ -26,7 +37,7 @@ def require(keys: list[str] | None = None) -> None:
 
     Raises
     ------
-    ValueError
+    ConfigError
         If any of the required keys are empty.
     """
 
@@ -34,5 +45,5 @@ def require(keys: list[str] | None = None) -> None:
     missing = [k for k in to_check if not globals().get(k)]
     if missing:
         joined = ", ".join(missing)
-        raise ValueError(f"Missing required config values: {joined}")
+        raise ConfigError(f"Missing required config values: {joined}")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ fastapi
 uvicorn
 celery
 redis
+python-dotenv

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,25 @@
+import importlib
+import os
+import sys
+import pytest
+
+
+def reload_config():
+    if 'config' in sys.modules:
+        del sys.modules['config']
+    return importlib.import_module('config')
+
+
+def test_require_missing(monkeypatch):
+    monkeypatch.delenv('PRINTIFY_API_KEY', raising=False)
+    monkeypatch.delenv('OPENAI_API_KEY', raising=False)
+    cfg = reload_config()
+    with pytest.raises(cfg.ConfigError):
+        cfg.require()
+
+
+def test_require_present(monkeypatch):
+    monkeypatch.setenv('PRINTIFY_API_KEY', 'key')
+    monkeypatch.setenv('OPENAI_API_KEY', 'key')
+    cfg = reload_config()
+    cfg.require()  # should not raise


### PR DESCRIPTION
## Summary
- load environment variables from `.env` if present
- add `ConfigError` and use it in `require()` for clearer messages
- provide `.env.example` template
- document `.env` usage in README
- add `python-dotenv` dependency
- unit test config validation

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c9c6b890c8324bae2c13666dfe166