### PR TITLE
Add merch collection generator feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ live development.
 The `creator_portal` directory implements a new FastAPI backend with modular
 agents for parsing blueprints, generating prompts and metadata, and optionally
 creating products on Printify. It now includes a plugin system, a simple search
-engine, and Celery background tasks. Launch it with:
+engine, Celery background tasks, and a merch collection generator agent.
+Launch it with:
 
 ```bash
 python toolkit.py creator-portal

--- a/creator_portal/agents/collection_generator.py
+++ b/creator_portal/agents/collection_generator.py
@@ -1,0 +1,42 @@
+"""Merch collection generator agent."""
+
+from typing import List, Optional
+
+from .blueprint_parser import Blueprint
+from .prompt_generator import generate_prompts
+from .metadata_gen import generate_metadata
+
+SEASONAL_COLLECTIONS = {
+    'summer': ['sunset vibes', 'tropical waves', 'beach party'],
+    'winter': ['snowflake dream', 'cozy cabin', 'mountain retreat'],
+    'spring': ['floral bloom', 'fresh rain', 'garden walk'],
+    'fall': ['harvest moon', 'pumpkin spice', 'autumn leaves'],
+}
+
+PERSONA_STYLES = {
+    'gamer': ['pixel hero', 'retro console', 'high score'],
+    'spiritual': ['chakra flow', 'mystic mandala', 'awakening mind'],
+    'minimalist': ['simple line art', 'monochrome shapes', 'clean geometry'],
+}
+
+
+def generate_collection(persona: Optional[str] = None,
+                         event: Optional[str] = None,
+                         items: int = 3) -> List[dict]:
+    """Generate a small merch collection based on persona or event."""
+    themes: List[str] = []
+    if persona and persona in PERSONA_STYLES:
+        themes = PERSONA_STYLES[persona]
+    elif event and event in SEASONAL_COLLECTIONS:
+        themes = SEASONAL_COLLECTIONS[event]
+
+    if not themes:
+        themes = ['abstract vibe']
+
+    results = []
+    for theme in themes[:items]:
+        bp = Blueprint(intent=theme, product_type='shirt')
+        prompt = generate_prompts(bp, num_variations=1)[0]
+        metadata = generate_metadata(bp)
+        results.append({'theme': theme, 'prompt': prompt, 'metadata': metadata})
+    return results

--- a/creator_portal/app.py
+++ b/creator_portal/app.py
@@ -23,6 +23,7 @@ from .agents.affiliate import generate_link, record_click, report
 from .agents.pricing import schedule_discount, list_schedules
 from .agents.import_tools import import_products
 from .agents.tax import calculate_tax
+from .agents.collection_generator import generate_collection
 from .plugins import list_plugins
 from .tasks import create_product_task, celery_app
 from fastapi.responses import PlainTextResponse
@@ -85,6 +86,12 @@ class ImportPayload(BaseModel):
 class TaxPayload(BaseModel):
     amount: float
     region: str
+
+
+class CollectionPayload(BaseModel):
+    persona: str | None = None
+    event: str | None = None
+    items: int = 3
 
 
 @app.post('/blueprint/parse')
@@ -216,6 +223,11 @@ def analytics_export():
 @app.get('/design/recommendations')
 def design_recs(num: int = 3):
     return design_recommendations(num)
+
+
+@app.post('/collection/generate')
+def collection_generate(payload: CollectionPayload):
+    return generate_collection(payload.persona, payload.event, payload.items)
 
 
 @app.post('/social/post')

--- a/tests/test_creator_portal_agents.py
+++ b/tests/test_creator_portal_agents.py
@@ -22,6 +22,7 @@ from creator_portal.agents.voice_assistant import register_command, trigger
 from creator_portal.agents.feedback import add_review, get_reviews
 from creator_portal.agents.price_tuning import record_sale, suggest_price
 from creator_portal.agents.style_match import match_style
+from creator_portal.agents.collection_generator import generate_collection
 from datetime import datetime
 from creator_portal.plugins import list_plugins
 from creator_portal.tasks import create_product_task, celery_app
@@ -137,4 +138,10 @@ def test_price_tuning():
 def test_style_match():
     results = match_style('retro')
     assert 'Sunset Tee' in results
+
+
+def test_collection_generator():
+    items = generate_collection(persona='gamer', items=2)
+    assert len(items) == 2
+    assert 'metadata' in items[0]
 


### PR DESCRIPTION
## Summary
- implement collection_generator agent for merch collections
- expose `/collection/generate` endpoint in FastAPI app
- test new functionality in creator portal agent tests
- mention collection generator in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d4439519083249386a5b3c3a411f7