### PR TITLE
Add analytics and marketplace enhancements

### DIFF
--- a/creator_portal/agents/analytics.py
+++ b/creator_portal/agents/analytics.py
@@ -25,3 +25,11 @@ def export_csv(data: List[Dict[str, int]]) -> str:
     writer.writeheader()
     writer.writerows(data)
     return output.getvalue()
+
+
+def average_sales(data: List[Dict[str, int]]) -> float:
+    """Return average sales from analytics data."""
+    if not data:
+        return 0.0
+    total = sum(item.get("sales", 0) for item in data)
+    return total / len(data)

--- a/creator_portal/agents/feedback.py
+++ b/creator_portal/agents/feedback.py
@@ -2,12 +2,14 @@
 
 from typing import List, Dict
 
-_REVIEWS: List[Dict[str, str]] = []
+_REVIEWS: List[Dict[str, float | str]] = []
 
 
-def add_review(product_id: str, review: str) -> Dict[str, str]:
-    """Store a review for a product."""
-    item = {"product_id": product_id, "review": review}
+def add_review(product_id: str, review: str, rating: float | None = None) -> Dict[str, float | str]:
+    """Store a review for a product with optional rating."""
+    item: Dict[str, float | str] = {"product_id": product_id, "review": review}
+    if rating is not None:
+        item["rating"] = rating
     _REVIEWS.append(item)
     return item
 
@@ -15,3 +17,11 @@ def add_review(product_id: str, review: str) -> Dict[str, str]:
 def get_reviews(product_id: str) -> List[str]:
     """Return all reviews for the product."""
     return [r["review"] for r in _REVIEWS if r["product_id"] == product_id]
+
+
+def average_rating(product_id: str) -> float:
+    """Return the average rating for the product or 0.0 if none."""
+    ratings = [float(r.get("rating", 0)) for r in _REVIEWS if r["product_id"] == product_id and "rating" in r]
+    if not ratings:
+        return 0.0
+    return sum(ratings) / len(ratings)

--- a/creator_portal/agents/marketplace.py
+++ b/creator_portal/agents/marketplace.py
@@ -16,3 +16,12 @@ def upload_design(name: str, author: str, url: str) -> Dict[str, str]:
 def list_designs() -> List[Dict[str, str]]:
     """Return all uploaded designs."""
     return list(_DESIGNS)
+
+
+def delete_design(name: str) -> bool:
+    """Remove a design by name. Returns True if deleted."""
+    for i, design in enumerate(_DESIGNS):
+        if design.get("name") == name:
+            del _DESIGNS[i]
+            return True
+    return False

--- a/creator_portal/agents/search.py
+++ b/creator_portal/agents/search.py
@@ -20,3 +20,8 @@ def search_products(term: str) -> List[Dict]:
         if term in title or any(term in t for t in tags):
             results.append(product)
     return results
+
+
+def count_products(term: str) -> int:
+    """Return the number of products matching the search term."""
+    return len(search_products(term))

--- a/creator_portal/agents/workflow.py
+++ b/creator_portal/agents/workflow.py
@@ -17,3 +17,8 @@ def run_template(name: str) -> List[str]:
     for step in steps:
         results.append(step())
     return results
+
+
+def list_templates() -> List[str]:
+    """Return the names of all registered templates."""
+    return list(_TEMPLATES.keys())


### PR DESCRIPTION
## Summary
- extend analytics agent to compute average sales
- allow counting search results
- support ratings on product reviews
- enable deleting designs from the marketplace
- expose list of workflow templates
- test new features

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d475268408324af512dd8056df0fa