### PR TITLE
Ensure start.sh uses venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,13 @@ This repository collects scripts and experiments for working with the Printify A
 
 ## Installation
 
-Create a virtual environment and install the required Python packages:
+Create a virtual environment and install the required Python packages. The
+`start.sh` helper will automatically create and activate `.venv` if it is not
+already active, but you can also do it manually:
 
 ```bash
+python3 -m venv .venv
+source .venv/bin/activate
 pip install -r requirements.txt
 ```
 

--- a/start.sh
+++ b/start.sh
@@ -3,6 +3,17 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Ensure a Python virtual environment is active
+if [ -z "${VIRTUAL_ENV:-}" ]; then
+    if [ ! -d "$DIR/.venv" ]; then
+        echo "Creating virtual environment..."
+        python3 -m venv "$DIR/.venv"
+    fi
+    echo "Activating virtual environment..."
+    # shellcheck disable=SC1091
+    source "$DIR/.venv/bin/activate"
+fi
+
 # Install Python dependencies
 if [ -f "$DIR/requirements.txt" ]; then
     echo "Installing Python dependencies..."


### PR DESCRIPTION
## Summary
- activate a local virtual environment in `start.sh` before installing Python deps
- document automatic venv creation in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d64d6f65083249b8a744e129e8fba