### PR TITLE
Add config skip to startup

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -3,6 +3,11 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Prevent Git from overwriting local config.py during pulls
+if git -C "$DIR" ls-files --error-unmatch config.py >/dev/null 2>&1; then
+    git -C "$DIR" update-index --skip-worktree config.py || true
+fi
+
 # Ensure a Python virtual environment is active
 if [ -z "${VIRTUAL_ENV:-}" ]; then
     if [ ! -d "$DIR/.venv" ]; then


### PR DESCRIPTION
## Summary
- prevent Git from overwriting `config.py` on pull by updating index

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d671b62b88324bca12ca4ed9898a1